### PR TITLE
Fix request JS secure for new node versions

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,5 @@
 var https = require('https');
-https.globalAgent.options.secureProtocol = 'SSLv3_method';
+https.globalAgent.options.secureProtocol = 'SSLv23_method';
 
 function Request(username, api_token) {
   this.api_token = api_token;


### PR DESCRIPTION
http://blog.nodejs.org/2014/10/23/node-v0-10-33-stable/

Based on this article, the secure methods set in the request.js module is no longer available and 23 is the default.
